### PR TITLE
SonarLint reports an unclosed Stream in test class

### DIFF
--- a/san-francisco-tourism/.gitignore
+++ b/san-francisco-tourism/.gitignore
@@ -2,6 +2,9 @@
 .classpath
 .project
 .settings
-.idea
+.idea/
 *.iml
+*.ipr
+*.iws
 /bin/
+

--- a/san-francisco-tourism/pom.xml
+++ b/san-francisco-tourism/pom.xml
@@ -1,48 +1,97 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.oracle.javaone.2017.hol.junit5</groupId>
-	<artifactId>san-francisco-tourism</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<properties>
-		<java.version>1.8</java.version>
-		<hamcrest.version>1.3</hamcrest.version>
-		<mockito.version>2.9.0</mockito.version>
-	</properties>
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.0</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-	<dependencies>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>${hamcrest.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>${mockito.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<version>3.6.2</version>
-		</dependency>
-	</dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+	http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.oracle.javaone.2017.hol.junit5</groupId>
+  <artifactId>san-francisco-tourism</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <prerequisites>
+    <maven>3.5.4</maven>
+  </prerequisites>
+
+  <properties>
+    <java.version>1.8</java.version>
+    <hamcrest.version>1.3</hamcrest.version>
+
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+    <maven.version>3.5.4</maven.version>
+
+    <mockito.version>2.22.0</mockito.version>
+
+    <project.encoding>UTF-8</project.encoding>
+    <project.build.sourceEncoding>${project.encoding}</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>${project.encoding}</project.reporting.outputEncoding>
+
+    <surefire.version>2.22.0</surefire.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.11.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.1</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>3.1.0</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.10.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.6</version>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/CableCarSchedule.java
+++ b/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/CableCarSchedule.java
@@ -1,9 +1,7 @@
 package com.javaone.hol2017.junit5;
 
-import java.time.*;
+import java.time.LocalTime;
 
 public interface CableCarSchedule {
-	
-	LocalTime nextCar();
-
+  LocalTime nextCar();
 }

--- a/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/CableCarWait.java
+++ b/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/CableCarWait.java
@@ -1,19 +1,20 @@
 package com.javaone.hol2017.junit5;
 
-import java.time.*;
-import java.time.temporal.*;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 
+@SuppressWarnings("WeakerAccess")
 public class CableCarWait {
 
-	private CableCarSchedule schedule;
+  private CableCarSchedule schedule;
 
-	public CableCarWait(CableCarSchedule schedule) {
-		this.schedule = schedule;
-	}
+  public CableCarWait(CableCarSchedule schedule) {
+    this.schedule = schedule;
+  }
 
-	public boolean timeForHotDog(LocalTime now) {
-		LocalTime nextCar = schedule.nextCar();
-		long minutesLeft = now.until(nextCar, ChronoUnit.MINUTES);
-		return minutesLeft > 15;
-	}
+  public boolean timeForHotDog(LocalTime now) {
+    LocalTime nextCar = schedule.nextCar();
+    long minutesLeft = now.until(nextCar, ChronoUnit.MINUTES);
+    return minutesLeft > 15;
+  }
 }

--- a/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/CableCars.java
+++ b/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/CableCars.java
@@ -1,17 +1,19 @@
 package com.javaone.hol2017.junit5;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
 
+@SuppressWarnings("WeakerAccess")
 public class CableCars {
 
-	private static final List<String> LINES = Arrays.asList("Powell-Hyde", "Powell-Mason", "California");
-	
-	public static int getNumberLines() {
-		return LINES.size();
-	}
-	
-	public static boolean isLine(String name) {
-		return LINES.contains(name);
-	}
-	
+  private static final List<String> LINES = Arrays.asList("Powell-Hyde", "Powell-Mason", "California");
+
+  public static int getNumberLines() {
+    return LINES.size();
+  }
+
+  public static boolean isLine(String name) {
+    return LINES.contains(name);
+  }
+
 }

--- a/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/Earthquake.java
+++ b/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/Earthquake.java
@@ -14,8 +14,7 @@ public class Earthquake {
     try {
       Thread.sleep(2000);
     }
-    catch (InterruptedException e) {
-      // ignore
+    catch (InterruptedException ignore) {
     }
   }
 

--- a/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/Earthquake.java
+++ b/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/Earthquake.java
@@ -1,28 +1,30 @@
 package com.javaone.hol2017.junit5;
 
+@SuppressWarnings("WeakerAccess")
 public class Earthquake {
 
-	public static class ShakeException extends RuntimeException {
+  public void shake(boolean strong) {
+    if (strong) {
+      throw new ShakeException("Wait for the aftershock...");
+    }
+  }
 
-		private static final long serialVersionUID = -7501336581318526078L;
+  // we are impatient, so let's only wait two seconds
+  public void waitForAftershock() {
+    try {
+      Thread.sleep(2000);
+    }
+    catch (InterruptedException e) {
+      // ignore
+    }
+  }
 
-		public ShakeException(String message) {
-			super(message);
-		}
-	}
+  public static class ShakeException extends RuntimeException {
 
-	public void shake(boolean strong) {
-		if (strong) {
-			throw new ShakeException("Wait for the aftershock...");
-		}
-	}
-	
-	// we are impatient, so let's only wait two seconds
-	public void waitForAftershock() {
-		try {
-			Thread.sleep(2000);
-		} catch (InterruptedException e) {
-			// ignore
-		}
-	}
+    private static final long serialVersionUID = -7501336581318526078L;
+
+    public ShakeException(String message) {
+      super(message);
+    }
+  }
 }

--- a/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/FishermansWharf.java
+++ b/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/FishermansWharf.java
@@ -1,24 +1,27 @@
 package com.javaone.hol2017.junit5;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
+@SuppressWarnings("WeakerAccess")
 public class FishermansWharf {
 
-	private List<SeaLion> seaLions;
+  private List<SeaLion> seaLions;
 
-	public FishermansWharf() {
-		seaLions = new ArrayList<>();
-	}
+  public FishermansWharf() {
+    seaLions = new ArrayList<>();
+  }
 
-	public String getUrl() {
-		return "http://www.fishermanswharf.org";
-	}
+  public String getUrl() {
+    return "http://www.fishermanswharf.org";
+  }
 
-	public void addSeaLion(SeaLion s) {
-		seaLions.add(s);
-	}
+  public void addSeaLion(SeaLion s) {
+    seaLions.add(s);
+  }
 
-	public Optional<SeaLion> getOldestSeaLion() {
-		return seaLions.stream().max((s1, s2) -> s1.getAge() - s2.getAge());
-	}
+  public Optional<SeaLion> getOldestSeaLion() {
+    return seaLions.stream().max((s1, s2) -> s1.getAge() - s2.getAge());
+  }
 }

--- a/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/FishermansWharfEnum.java
+++ b/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/FishermansWharfEnum.java
@@ -1,17 +1,17 @@
 package com.javaone.hol2017.junit5;
 
-import java.time.*;
+import java.time.LocalTime;
 
 public enum FishermansWharfEnum {
-	STORES(22), RESTAURANTS(23), FOOD_CARTS(21);
+  STORES(22), RESTAURANTS(23), FOOD_CARTS(21);
 
-	private LocalTime closing;
+  private LocalTime closing;
 
-	FishermansWharfEnum(int closingHour) {
-		closing = LocalTime.of(closingHour, 0);
-	}
+  FishermansWharfEnum(int closingHour) {
+    closing = LocalTime.of(closingHour, 0);
+  }
 
-	public LocalTime closes() {
-		return closing;
-	}
+  public LocalTime closes() {
+    return closing;
+  }
 }

--- a/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/SeaLion.java
+++ b/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/SeaLion.java
@@ -1,48 +1,48 @@
 package com.javaone.hol2017.junit5;
 
+@SuppressWarnings("WeakerAccess")
 public class SeaLion {
 
-	private int age;
-	private int weight;
-	private boolean male;
+  private int age;
+  private int weight;
+  private boolean male;
 
-	public SeaLion(int age, int weight, boolean male) {
-		super();
-		this.age = age;
-		this.weight = weight;
-		this.male = male;
-	}
+  public SeaLion(int age, int weight, boolean male) {
+    super();
+    this.age = age;
+    this.weight = weight;
+    this.male = male;
+  }
 
-	public int getAge() {
-		return age;
-	}
+  public int getAge() {
+    return age;
+  }
 
-	public int getWeight() {
-		return weight;
-	}
+  public int getWeight() {
+    return weight;
+  }
 
-	public boolean isMale() {
-		return male;
-	}
+  public boolean isMale() {
+    return male;
+  }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + age;
-		result = prime * result + (male ? 1231 : 1237);
-		result = prime * result + weight;
-		return result;
-	}
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + age;
+    result = prime * result + (male ? 1231 : 1237);
+    result = prime * result + weight;
+    return result;
+  }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null || getClass() != obj.getClass())
-			return false;
-		SeaLion other = (SeaLion) obj;
-		return age == other.age && male == other.male && weight == other.weight;
-	}
-
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null || getClass() != obj.getClass())
+      return false;
+    SeaLion other = (SeaLion) obj;
+    return age == other.age && male == other.male && weight == other.weight;
+  }
 }

--- a/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/ThirtyNinthAnniversaryEvents.java
+++ b/san-francisco-tourism/src/main/java/com/javaone/hol2017/junit5/ThirtyNinthAnniversaryEvents.java
@@ -1,42 +1,43 @@
 package com.javaone.hol2017.junit5;
 
-import java.time.*;
-import java.util.*;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Pier 39 is celebrating it's 39th anniversary with events every Friday for the
  * first 39 weeks of 2017.
- *
  */
 public class ThirtyNinthAnniversaryEvents {
-	
-	private static Set<LocalDate> specialDates = listSpecialDates();
 
-	private ThirtyNinthAnniversaryEvents() {
-		super();
-	}
+  private static Set<LocalDate> specialDates = listSpecialDates();
 
-	private static Set<LocalDate> listSpecialDates() {
-		Set<LocalDate> result = new HashSet<>();
-		LocalDate friday = getFirstFriday(2017);
-		for (int i = 0; i <= 39; i++) {
-			result.add(friday);
-			friday = friday.plusWeeks(1);
-		}
-		result.add(friday);
-		return result;
-	}
+  private ThirtyNinthAnniversaryEvents() {
+    super();
+  }
 
-	public static boolean isCelebrationDay(LocalDate date) {
-		return specialDates.contains(date);
-	}
+  private static Set<LocalDate> listSpecialDates() {
+    Set<LocalDate> result = new HashSet<>();
+    LocalDate friday = getFirstFriday(2017);
+    for (int i = 0; i <= 39; i++) {
+      result.add(friday);
+      friday = friday.plusWeeks(1);
+    }
+    result.add(friday);
+    return result;
+  }
 
-	private static LocalDate getFirstFriday(int year) {
-		LocalDate candidate = LocalDate.of(year, 1, 1);
-		while (candidate.getDayOfWeek() != DayOfWeek.FRIDAY) {
-			candidate = candidate.plusDays(1);
-		}
-		return candidate;
-	}
+  public static boolean isCelebrationDay(LocalDate date) {
+    return specialDates.contains(date);
+  }
+
+  private static LocalDate getFirstFriday(int year) {
+    LocalDate candidate = LocalDate.of(year, 1, 1);
+    while (candidate.getDayOfWeek() != DayOfWeek.FRIDAY) {
+      candidate = candidate.plusDays(1);
+    }
+    return candidate;
+  }
 
 }

--- a/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/CableCarWaitTest.java
+++ b/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/CableCarWaitTest.java
@@ -1,49 +1,52 @@
 package com.javaone.hol2017.junit5;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-import java.time.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.junit.*;
-import org.junit.runner.*;
-import org.mockito.*;
-import org.mockito.junit.*;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CableCarWaitTest {
 
-	@Mock
-	CableCarSchedule mockSchedule;
+  @Mock
+  CableCarSchedule mockSchedule;
 
-	CableCarWait target;
+  CableCarWait target;
 
-	@Before
-	public void setUp() {
-		target = new CableCarWait(mockSchedule);
-	}
+  @Before
+  public void setUp() {
+    target = new CableCarWait(mockSchedule);
+  }
 
-	@Test
-	public void plentyOfTime() {
-		LocalTime noon = LocalTime.of(12, 0);
-		LocalTime halfHourEarlier = LocalTime.of(11, 30);
-		when(mockSchedule.nextCar()).thenReturn(noon);
-		assertTrue(target.timeForHotDog(halfHourEarlier));
-	}
-	
-	@Test
-	public void anyMinuteNow() {
-		LocalTime noon = LocalTime.of(12, 0);
-		LocalTime justEarlier = LocalTime.of(11, 59);
-		when(mockSchedule.nextCar()).thenReturn(noon);
-		assertFalse(target.timeForHotDog(justEarlier));
-	}
-	
-	@Test
-	public void barelyEnoughTime() {
-		LocalTime noon = LocalTime.of(12, 0);
-		LocalTime fifteenMinutesEarlier = LocalTime.of(11, 45);
-		when(mockSchedule.nextCar()).thenReturn(noon);
-		assertFalse(target.timeForHotDog(fifteenMinutesEarlier));
-	}
+  @Test
+  public void plentyOfTime() {
+    LocalTime noon = LocalTime.of(12, 0);
+    LocalTime halfHourEarlier = LocalTime.of(11, 30);
+    when(mockSchedule.nextCar()).thenReturn(noon);
+    assertThat(target.timeForHotDog(halfHourEarlier)).isTrue();
+  }
 
+  @Test
+  public void anyMinuteNow() {
+    LocalTime noon = LocalTime.of(12, 0);
+    LocalTime justEarlier = LocalTime.of(11, 59);
+    when(mockSchedule.nextCar()).thenReturn(noon);
+    assertThat(target.timeForHotDog(justEarlier)).isFalse();
+  }
+
+  @Test
+  public void barelyEnoughTime() {
+    LocalTime noon = LocalTime.of(12, 0);
+    LocalTime fifteenMinutesEarlier = LocalTime.of(11, 45);
+    when(mockSchedule.nextCar()).thenReturn(noon);
+    assertFalse(target.timeForHotDog(fifteenMinutesEarlier));
+  }
 }

--- a/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/CableCarsTest.java
+++ b/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/CableCarsTest.java
@@ -1,26 +1,27 @@
 package com.javaone.hol2017.junit5;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
 
-import org.assertj.core.api.*;
-import org.junit.*;
+import org.assertj.core.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class CableCarsTest {
 
-	@Test
-	public void numberLines() {
-		int actual = CableCars.getNumberLines();
-		assertEquals(3, actual);
-	}
-	
-	@Test
-	public void namesOfLines() {
-		SoftAssertions softly = new SoftAssertions();
-		softly.assertThat(CableCars.isLine("California")).isTrue().as("California");
-		softly.assertThat(CableCars.isLine("Powell-Hyde")).isTrue().as("Powell-Hyde");
-		softly.assertThat(CableCars.isLine("Powell-Mason")).isTrue().as("Powell-Mason");
-		softly.assertThat(CableCars.isLine("San Francisco")).isFalse().as("San Francisco");
-		softly.assertAll();
-	}
+  @Test
+  public void numberLines() {
+    int actual = CableCars.getNumberLines();
+    assertThat(actual).isEqualTo(3);
+  }
 
+  @Test
+  public void namesOfLines() {
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(CableCars.isLine("California")).isTrue().as("California");
+    softly.assertThat(CableCars.isLine("Powell-Hyde")).isTrue().as("Powell-Hyde");
+    softly.assertThat(CableCars.isLine("Powell-Mason")).isTrue().as("Powell-Mason");
+    softly.assertThat(CableCars.isLine("San Francisco")).isFalse().as("San Francisco");
+    softly.assertAll();
+  }
 }

--- a/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/EarthquakeTest.java
+++ b/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/EarthquakeTest.java
@@ -1,44 +1,47 @@
 package com.javaone.hol2017.junit5;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
-import org.junit.*;
-import org.junit.rules.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import com.javaone.hol2017.junit5.Earthquake.*;
+import com.javaone.hol2017.junit5.Earthquake.ShakeException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class EarthquakeTest {
 
-	@Rule
-	public ExpectedException expected = ExpectedException.none();
+  @Rule
+  public ExpectedException expected = ExpectedException.none();
 
-	private Earthquake earthquake;
+  private Earthquake earthquake;
 
-	@Before
-	public void setUp() {
-		earthquake = new Earthquake();
-	}
+  @Before
+  public void setUp() {
+    earthquake = new Earthquake();
+  }
 
-	@Test(expected = ShakeException.class)
-	public void noMessageChecking() {
-		earthquake.shake(true);
-	}
+  @Test(expected = ShakeException.class)
+  public void noMessageChecking() {
+    earthquake.shake(true);
+  }
 
-	@Test
-	public void usingRule() {
-		expected.expect(ShakeException.class);
-		expected.expectMessage("Wait for the aftershock");
-		earthquake.shake(true);
-	}
+  @Test
+  public void usingRule() {
+    expected.expect(Earthquake.ShakeException.class);
+    expected.expectMessage("Wait for the aftershock");
+    earthquake.shake(true);
+  }
 
-	@Test
-	public void usingStandalone() {
-		try {
-			earthquake.shake(true);
-			fail("should throw exception");
-		} catch (ShakeException e) {
-			assertThat(e.getMessage(), containsString("Wait for the aftershock"));
-		}
-	}
-
+  @Test
+  public void usingStandalone() {
+    try {
+      earthquake.shake(true);
+      failBecauseExceptionWasNotThrown(Earthquake.ShakeException.class);
+    }
+    catch (Earthquake.ShakeException e) {
+      assertThat(e.getMessage()).contains("Wait for the aftershock");
+    }
+  }
 }

--- a/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/EarthquakeTimeoutTest.java
+++ b/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/EarthquakeTimeoutTest.java
@@ -1,19 +1,20 @@
 package com.javaone.hol2017.junit5;
 
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 
 public class EarthquakeTimeoutTest {
 
-	private Earthquake earthquake;
+  private Earthquake earthquake;
 
-	@Before
-	public void setUp() {
-		earthquake = new Earthquake();
-	}
+  @Before
+  public void setUp() {
+    earthquake = new Earthquake();
+  }
 
-	@Test(timeout = 6000)
-	public void timeout() {
-		earthquake.waitForAftershock();
-	}
+  @Test(timeout = 6000)
+  public void timeout() {
+    earthquake.waitForAftershock();
+  }
 
 }

--- a/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/FishermansWharfEnumTest.java
+++ b/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/FishermansWharfEnumTest.java
@@ -1,20 +1,20 @@
 package com.javaone.hol2017.junit5;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import org.junit.Test;
 
-import java.time.*;
+import java.time.LocalTime;
 
-import org.junit.*;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertThat;
 
 public class FishermansWharfEnumTest {
 
-	@Test
-	public void allClosingTimesAfter9pm() {
-		LocalTime ninePm = LocalTime.of(12 + 9, 0);
-		for (FishermansWharfEnum current : FishermansWharfEnum.values()) {
-			assertThat(current + " should close after 9pm", current.closes(), greaterThanOrEqualTo(ninePm));
-		}
-	}
+  @Test
+  public void allClosingTimesAfter9pm() {
+    LocalTime ninePm = LocalTime.of(12 + 9, 0);
+    for (FishermansWharfEnum current : FishermansWharfEnum.values()) {
+      assertThat(current + " should close after 9pm", current.closes(), greaterThanOrEqualTo(ninePm));
+    }
+  }
 
 }

--- a/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/FishermansWharfTest.java
+++ b/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/FishermansWharfTest.java
@@ -1,42 +1,47 @@
 package com.javaone.hol2017.junit5;
 
-import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
 
-import org.junit.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class FishermansWharfTest {
 
-	private FishermansWharf wharf;
+  private FishermansWharf wharf;
 
-	@Before
-	public void createWharf() {
-		wharf = new FishermansWharf();
-	}
+  @Before
+  public void createWharf() {
+    wharf = new FishermansWharf();
+  }
 
-	@Test
-	public void url() {
-		assertEquals("url", "http://www.fishermanswharf.org", wharf.getUrl());
-	}
-	
-	@Test
-	public void oldestSeaLionForEmptyList() {
-		assertFalse(wharf.getOldestSeaLion().isPresent());
-	}
-	
-	@Test
-	public void oldestSeaLionForFirstElement() {
-		wharf.addSeaLion(new SeaLion(15, 200, true));
-		wharf.addSeaLion(new SeaLion(10, 150, false));
-		SeaLion actual = wharf.getOldestSeaLion().get();
-		assertEquals(15, actual.getAge());
-	}
-	
-	@Test
-	public void oldestSeaLionForLastElement() {
-		wharf.addSeaLion(new SeaLion(10, 150, false));
-		wharf.addSeaLion(new SeaLion(15, 200, true));
-		SeaLion actual = wharf.getOldestSeaLion().get();
-		assertEquals("oldest", 15, actual.getAge());
-	}
+  @Test
+  public void url() {
+    assertEquals("url", "http://www.fishermanswharf.org", wharf.getUrl());
+    assertThat(wharf.getUrl()).isEqualTo("http://www.fishermanswharf.org");
+  }
 
+  @Test
+  public void oldestSeaLionForEmptyList() {
+    assertThat(wharf.getOldestSeaLion().isPresent()).isFalse();
+  }
+
+  @Test
+  public void oldestSeaLionForFirstElement() {
+    wharf.addSeaLion(new SeaLion(15, 200, true));
+    wharf.addSeaLion(new SeaLion(10, 150, false));
+    SeaLion actual = wharf.getOldestSeaLion().get();
+    assertThat(actual.getAge()).isEqualTo(15);
+  }
+
+  @Test
+  public void oldestSeaLionForLastElement() {
+    wharf.addSeaLion(new SeaLion(10, 150, false));
+    wharf.addSeaLion(new SeaLion(15, 200, true));
+    SeaLion actual = wharf.getOldestSeaLion().get();
+    assertEquals("oldest", 15, actual.getAge());
+
+    assertThat(actual.getAge()).isEqualTo(15);
+  }
 }

--- a/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/SeaLionTest.java
+++ b/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/SeaLionTest.java
@@ -1,40 +1,51 @@
 package com.javaone.hol2017.junit5;
 
-import static org.junit.Assert.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
-import org.junit.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /*
  * Clearly this test doesn't cover all the cases, but good enough o show JUnit 5 ;)
  */
 public class SeaLionTest {
 
-	private static SeaLion seaLion1;
-	private static SeaLion seaLion2;
+  private static SeaLion seaLion1;
+  private static SeaLion seaLion2;
 
-	@BeforeClass
-	public static void createSeaLions() {
-		seaLion1 = new SeaLion(1, 75, true);
-		seaLion2 = new SeaLion(2, 125, false);
-	}
+  @BeforeClass
+  public static void createSeaLions() {
+    seaLion1 = new SeaLion(1, 75, true);
+    seaLion2 = new SeaLion(2, 125, false);
+  }
 
-	@AfterClass
-	public static void tearDown() {
-		seaLion1 = null;
-		seaLion2 = null;
-	}
+  @AfterClass
+  public static void tearDown() {
+    seaLion1 = null;
+    seaLion2 = null;
+  }
 
-	@Test
-	public void hashCodeValues() {
-		assertEquals("same", seaLion1.hashCode(), seaLion1.hashCode());
-		assertNotEquals("different", seaLion1.hashCode(), seaLion2.hashCode());
-	}
+  @Test
+  public void testGetters() {
+    assertThat(seaLion1.isMale()).isTrue();
+    assertThat(seaLion2.isMale()).isFalse();
 
-	@Test
-	public void equalsValues() {
-		assertTrue("same", seaLion1.equals(seaLion1));
-		assertFalse("null", seaLion1.equals(null));
-		assertFalse("different", seaLion1.equals(seaLion2));
-	}
+    assertThat(seaLion1.getWeight()).isEqualTo(75);
+    assertThat(seaLion2.getWeight()).isEqualTo(125);
+  }
 
+  @Test
+  public void hashCodeValues() {
+    assertThat(seaLion1.hashCode()).isEqualTo(seaLion1.hashCode());
+    assertThat(seaLion1.hashCode()).isNotNull();
+    assertThat(seaLion1.hashCode()).isNotEqualTo(seaLion2.hashCode());
+  }
+
+  @Test
+  public void equalsValues() {
+    assertThat(seaLion1).isEqualTo(seaLion1);
+    assertThat(seaLion1).isNotNull();
+    assertThat(seaLion1).isNotEqualTo(seaLion2);
+  }
 }

--- a/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/ShakeExceptionTest.java
+++ b/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/ShakeExceptionTest.java
@@ -1,18 +1,20 @@
 package com.javaone.hol2017.junit5;
 
-import static org.junit.Assert.*;
+import org.junit.Ignore;
+import org.junit.Test;
 
-import org.junit.*;
+import com.javaone.hol2017.junit5.Earthquake.ShakeException;
 
-import com.javaone.hol2017.junit5.Earthquake.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ShakeExceptionTest {
 
-	@Test @Ignore("this test is ignored becuase it is unnecessary")
-	public void message() {
-		String expected = "message";
-		ShakeException actual = new ShakeException(expected);
-		assertEquals(expected, actual.getMessage());
-	}
+  @Ignore("this test execution has been disabled because it is unnecessary")
+  @Test
+  public void message() {
+    String expected = "message";
+    ShakeException actual = new ShakeException(expected);
 
+    assertThat(actual.getMessage()).isEqualTo(expected);
+  }
 }

--- a/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/ThirtyNinthAnniversaryEventsTest.java
+++ b/san-francisco-tourism/src/test/java/com/javaone/hol2017/junit5/ThirtyNinthAnniversaryEventsTest.java
@@ -1,43 +1,57 @@
 package com.javaone.hol2017.junit5;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
-import java.io.*;
-import java.nio.file.*;
-import java.time.*;
-import java.util.*;
-import java.util.stream.*;
+import org.apache.commons.lang3.StringUtils;
 
-import org.junit.*;
-import org.junit.runner.*;
-import org.junit.runners.*;
-import org.junit.runners.Parameterized.*;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 @RunWith(Parameterized.class)
 public class ThirtyNinthAnniversaryEventsTest {
-	
-	@Parameter(0) public LocalDate date;
-	@Parameter(1) public boolean expectedResult;
 
-	@Parameters(name="{0}")
-	public static Collection<Object[]> testCases() throws IOException {
-		Path path = Paths.get("src/test/resources", "39-tests.txt");
-		return Files.lines(path)
-				// remove blank and commented out lines
-				.filter(l -> ! l.isEmpty())
-				.filter(l -> ! l.startsWith("#"))
-				// convert to array
-				.map(l -> l.split(","))
-				// convert to desired types for parameterized test
-				.map(a -> new Object[] { LocalDate.parse(a[0]), Boolean.parseBoolean(a[1])} )
-				// store in collection
-				.collect(Collectors.toList());
-	}
-	
-	@Test
-	public void date() {
-		boolean actual = ThirtyNinthAnniversaryEvents.isCelebrationDay(date);
-		assertEquals(expectedResult, actual);
-	}
+  @Parameter
+  public LocalDate date;
 
+  @Parameter(1)
+  public boolean expectedResult;
+
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> testCases() throws IOException {
+    Path path = Paths.get("src/test/resources", "39-tests.txt");
+
+    List<String> linesFromFile = Files.readAllLines(path, StandardCharsets.UTF_8);
+
+    return linesFromFile.stream()
+      // remove blank and commented out lines
+      .filter(StringUtils::isNotBlank)
+      .filter(l -> !l.startsWith("#"))
+      // convert to array
+      .map(l -> l.split(","))
+      // convert to desired types for parameterized test
+      .map(a -> new Object[]{LocalDate.parse(a[0]), Boolean.parseBoolean(a[1])})
+      // store in collection
+      .collect(Collectors.toList());
+  }
+
+  @Test
+  public void dateTest() {
+    boolean actual = ThirtyNinthAnniversaryEvents.isCelebrationDay(date);
+
+    assertThat(actual).isEqualTo(expectedResult);
+  }
 }


### PR DESCRIPTION
The current version of the IntelliJ SonarLint plugin installed in the current as of 09/27/2018 version of IntelliJ was complaining about an unclosed stream in the 1st version of the testCases method below. It actually took me a while to fix the problem, mostly because I very rarely find myself doing much with the file system, and so am not very familiar with the Java 8 enhanced from Java 7 Paths or Files classes.

The problem line was return Files.lines(path)... The SonarLint compliant solution that I was able to identify involved adding an additional call to List<String> linesFromFile = Files.readAllLines(path, StandardCharsets.UTF_8); which will exeute an auto-close when the method completes reading the file contents. Following that it was easy enough to substitute a reference to linesFromFile.stream() to recapture the original behavior. 

I'll submit a pull request with the proposed changes soon. Made a mess of minor changes of various kinds. 

Am intolerant of any "*"'s in import statements, and insist on the explicit declaration of each imported class. Format all files with 2 spaces of indentation and remove any and all tabs, or at least I try to so by configuring any IDEs that I use to do so. I don't necessarily determine whether they actually work as anticipated. Always bump the versions of all dependencies and plugins to current, and push back only those that cause problems. Attempt to convert predicates from !x to notX(), so replaced 

 .filter(l -> ! l.isEmpty()) with .filter(StringUtils::isNotBlank)

I'd be happy to discuss any of this.

I did attempt to write  a description of what SonarLint was complaining about and to display the solution that I dreamed up, but my too meagre skills at formatting text got in the way yet again.